### PR TITLE
Add Makefile for CI test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+# md5sum binary
+MD5SUM = md5sum
+
+# tinygo binary for tests
+TINYGO ?= tinygo
+
+.PHONY: all clean fmt fmt-check
+
+all:
+
+clean:
+	@rm -f $(TARGET)
+
+FMT_PATHS = ./*.go cmd freemono freesans freeserif gophers proggy examples
+fmt:
+	@gofmt -l -w $(FMT_PATHS)
+fmt-check:
+	@unformatted=$$(gofmt -l $(FMT_PATHS)); [ -z "$$unformatted" ] && exit 0; echo "Unformatted:"; for fn in $$unformatted; do echo "  $$fn"; done; exit 1
+
+TARGET = examples_epd.hex \
+		 examples_hub75.hex \
+		 examples_pybadge.hex \
+		 examples_pyportal.hex
+.PHONY: smoketest $(TARGET)
+smoketest: $(TARGET)
+	$(TINYGO) version
+
+examples_epd.hex:
+	$(TINYGO) build -size short -o $@ -target=microbit            ./examples/epd
+	@$(MD5SUM) $@
+
+examples_hub75.hex:
+	$(TINYGO) build -size short -o $@ -target=pybadge             ./examples/hub75
+	@$(MD5SUM) $@
+
+examples_pybadge.hex:
+	$(TINYGO) build -size short -o $@ -target=pybadge             ./examples/pybadge
+	@$(MD5SUM) $@
+
+examples_pyportal.hex:
+	$(TINYGO) build -size short -o $@ -target=pyportal            ./examples/pyportal
+	@$(MD5SUM) $@


### PR DESCRIPTION
Resolves #9 

Based on a Makefile from the tinygo project.
At the moment, `smoketest` and `clean` and `fmt` and `fmt-check` work.
`all` is empty because there is nothing to do.

I checked it with bash on windows.
I checked it with docker (tinygo/tinygo-dev).

The `examples_*.hex` target is created separately so that it can be accelerated with `make -j4` and so on.
If you add example, you will need the following

1. add to TARGET
2. add `examples_*.hex` target