### PR TITLE
Fix a panic caused by out-of-range characters.

### DIFF
--- a/tinyfont.go
+++ b/tinyfont.go
@@ -83,6 +83,9 @@ func WriteLineRotated(display drivers.Displayer, font *Font, x int16, y int16, t
 	w, h := display.Size()
 	l := len(text)
 	for i := 0; i < l; i++ {
+		if text[i] < font.First || text[i] > font.Last {
+			continue
+		}
 		glyph := font.Glyphs[text[i]-font.First]
 		//if x+int16(glyph.XAdvance) >= 0 {
 		DrawCharRotated(display, font, x, y, text[i], color, rotation)


### PR DESCRIPTION
Hi,

This fixes a panic triggered by unsupported characters.

The problem was that `WriteLineRotated` missed a range check before
accessing `font.Glyphs` similar to the one in `DrawCharRotated`.

Here is the stacktrace I got:
```go
panic: runtime error: index out of range [234] with length 95

goroutine 1 [running]:
tinygo.org/x/tinyfont.WriteLineRotated(0x3acc80, 0xb09090, 0x566c70, 0x14000d, 0x835eec, 0x8, 0x20, 0xffffffff, 0x0)
        /Users/ilya/projects/tinyapple/vendor/tinygo.org/x/tinyfont/tinyfont.go:86 +0x300
tinygo.org/x/tinyfont.WriteLine(...)
        /Users/ilya/projects/tinyapple/vendor/tinygo.org/x/tinyfont/tinyfont.go:77
main.main()
        /Users/ilya/projects/tinyapple/cmd/bot/main.go:69 +0x798
```

Please let me know if you need me to provide more info or make any further code changes.
Thank you.