### PR TITLE
examples: change to stay at main()

### DIFF
--- a/examples/displays/main.go
+++ b/examples/displays/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"image/color"
+	"time"
 
 	"tinygo.org/x/tinyfont/examples/initdisplay"
 	"tinygo.org/x/tinyfont/freemono"
@@ -26,6 +27,9 @@ func main() {
 
 	tinyfont.WriteLineColors(display, &gophers.Regular58pt, 18, 90, "ABC", mycolors[9:])
 
+	for {
+		time.Sleep(time.Hour)
+	}
 }
 
 func getRainbowRGB(i uint8) color.RGBA {

--- a/examples/epd/main.go
+++ b/examples/epd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"machine"
+	"time"
 
 	"image/color"
 
@@ -42,6 +43,10 @@ func main() {
 	display.Display()
 	display.WaitUntilIdle()
 	println("You could remove power now")
+
+	for {
+		time.Sleep(time.Hour)
+	}
 }
 
 func showRect(x int16, y int16, w int16, h int16, c color.RGBA) {

--- a/examples/unicode_font/main.go
+++ b/examples/unicode_font/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"image/color"
+	"time"
 
 	"tinygo.org/x/tinyfont"
 	"tinygo.org/x/tinyfont/examples/initdisplay"
@@ -27,4 +28,8 @@ func main() {
 		"\u2934\u2935\u2B05\u2B06\u2B07\u2B1B\u2B1C\u2B50\u2B55\n" +
 		"\u3030\u303D\u3297\u3299\uFEFF"
 	tinyfont.WriteLine(display, &notoemoji.NotoEmojiRegular20pt, 3, 0x16, str, color.RGBA{0, 0, 0, 255})
+
+	for {
+		time.Sleep(time.Hour)
+	}
 }

--- a/examples/unicode_font2/main.go
+++ b/examples/unicode_font2/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"image/color"
+	"time"
 
 	"tinygo.org/x/tinyfont"
 	"tinygo.org/x/tinyfont/examples/initdisplay"
@@ -34,4 +35,8 @@ func main() {
 		"Uzbek — Ўзбекча\n"
 
 	tinyfont.WriteLine(display, &notosans.Notosans12pt, 3, 0x16, str, color.RGBA{0, 0, 0, 255})
+
+	for {
+		time.Sleep(time.Hour)
+	}
 }


### PR DESCRIPTION
Because after main(), you will not be able to tinygo flash after exiting main().
This is comfortable even without a debugger.