### PR TITLE
Support for tinygo.org/x/drivers 0.14

### DIFF
--- a/examples/initdisplay/wioterminal.go
+++ b/examples/initdisplay/wioterminal.go
@@ -19,7 +19,7 @@ func InitDisplay() drivers.Displayer {
 		Frequency: 40000000,
 	})
 
-	d := ili9341.NewSpi(
+	d := ili9341.NewSPI(
 		machine.SPI3,
 		machine.LCD_DC,
 		machine.LCD_SS_PIN,

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module tinygo.org/x/tinyfont
 
 go 1.15
 
-require tinygo.org/x/drivers v0.12.1-0.20200803135816-8163dec7c324
+require tinygo.org/x/drivers v0.14.0


### PR DESCRIPTION
With drivers 0.14, I get an error.

```
$ tinygo build -o app.hex --target wioterminal tinygo.org/x/tinyfont/examples/displays
# tinygo.org/x/tinyfont/examples/initdisplay
../dev/pkg/mod/tinygo.org/x/tinyfont@v0.0.0-20200917110732-4eca5acda0e0/examples/initdisplay/wioterminal.go:22:15: NewSpi not declared by package ili9341
```

note:
https://github.com/tinygo-org/drivers/pull/199
