### PR TITLE
go mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module tinygo.org/x/tinyfont
 
 go 1.15
 
-require tinygo.org/x/drivers v0.14.0
+require tinygo.org/x/drivers v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/eclipse/paho.mqtt.golang v1.2.0/go.mod h1:H9keYFcgq3Qr5OUJm/JZI/i6U7joQ8SYLhZwfeOo6Ts=
+github.com/frankban/quicktest v1.10.2/go.mod h1:K+q6oSqb0W0Ininfk863uOk1lMy69l/P6txr3mVT54s=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+tinygo.org/x/drivers v0.16.0 h1:U+cOLx21iT8clWtBqbHzXZE2yDkCrjk7AitTdwLQwJc=
+tinygo.org/x/drivers v0.16.0/go.mod h1:uT2svMq3EpBZpKkGO+NQHjxjGf1f42ra4OnMMwQL2aI=


### PR DESCRIPTION
Need to add go.sum to fix the error in CI.
I ran the `go mod download tinygo.org/x/drivers` and registered `go.mod` and `go.sum`.

https://app.circleci.com/pipelines/github/tinygo-org/tinyfont/26/workflows/b8103131-4f3a-4068-b194-ca2bd7bd777f/jobs/27
```
#!/bin/bash -eo pipefail
make smoketest

tinygo build -size short -o examples_epd.hex -target=microbit            ./examples/epd
go: tinygo.org/x/drivers@v0.14.0: missing go.sum entry; to add it:
	go mod download tinygo.org/x/drivers
make: *** [Makefile:34: examples_epd.hex] Error 1

Exited with code exit status 2

CircleCI received exit code 2
```