### PR TITLE
tinyfontgen-ttf: remove NULL character

### DIFF
--- a/cmd/tinyfontgen-ttf/main.go
+++ b/cmd/tinyfontgen-ttf/main.go
@@ -239,7 +239,11 @@ func (f Font) SaveTo(w io.Writer) {
 	for _, x := range f.Glyphs {
 		fmt.Fprintf(w, `	"\x%02X\x%02X\x%02X" + `, byte(x.Rune>>16), byte(x.Rune>>8), byte(x.Rune))
 		fmt.Fprintf(w, `"\x%02X\x%02X\x%02X" + `, byte(offset>>16), byte(offset>>8), byte(offset))
-		fmt.Fprintf(w, `// %c`, x.Rune)
+		if x.Rune > 0 {
+			fmt.Fprintf(w, `// %c`, x.Rune)
+		} else {
+			fmt.Fprintf(w, `//`)
+		}
 		fmt.Fprintf(w, "\n")
 
 		// width + height + xadvance + xoffset + yoffset + len([]bitmaps)


### PR DESCRIPTION
When the following font was used for generation, NULL characters were generated in the comments and the build failed.

![image](https://user-images.githubusercontent.com/9251039/183268821-c4c4b1fd-c6f8-4027-923b-a63efffc9169.png)

This is not only TinyGo, but also Go cannot be built.
Therefore, it has been corrected so that the NULL character is not included in the comment.

```
arfelickfeather\font.go:18:39: invalid NUL character
```


----

After modification, it works well as follows.

https://fontsfree.net/arfelick-feather-font-download.html

```
$ go run ./cmd/tinyfontgen-ttf --size 32 --package arfelickfeather --fontname ArfelickFeather32pt ./_fonts/FontsFree-NetArfelickFeather.ttf --output arfelickfeather/font.go
```

```go
package main

import (
	"fmt"
	"image/color"

	"tinygo.org/x/tinyfont"
	"tinygo.org/x/tinyfont/arfelickfeather"
	"tinygo.org/x/tinyfont/examples/initdisplay"
)

func main() {
	font := arfelickfeather.ArfelickFeather32pt
	display := initdisplay.InitDisplay()

	msg := fmt.Sprintf("%s\n1234567890\nHello TinyFont", font.Name)
	tinyfont.WriteLine(display, &font, 10, 35, msg, color.RGBA{A: 0xFF})

	select {}
}
```

![image](https://user-images.githubusercontent.com/9251039/183268779-c8147eef-caa6-49ef-8381-80184b479c4b.png)