### PR TITLE
all: avoid all heap allocations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ TINYGO ?= tinygo
 
 .PHONY: all clean fmt fmt-check
 
-all:
+all: fmt fmt-check smoke-test
 
 clean:
 	@mkdir -p build

--- a/concrete.go
+++ b/concrete.go
@@ -53,8 +53,8 @@ func (glyph Glyph) Draw(display drivers.Displayer, x int16, y int16, color color
 }
 
 // Info returns glyph information.
-func (glyph Glyph) Info() *GlyphInfo {
-	return &GlyphInfo{
+func (glyph Glyph) Info() GlyphInfo {
+	return GlyphInfo{
 		Rune:     glyph.Rune,
 		Width:    glyph.Width,
 		Height:   glyph.Height,
@@ -69,8 +69,10 @@ func (f *Font) GetYAdvance() uint8 {
 	return f.YAdvance
 }
 
+var emptyBitmap [1]byte
+
 // GetGlyph returns the glyph corresponding to the specified rune in the font.
-func (font *Font) GetGlyph(r rune) Glypher {
+func (font *Font) GetGlyph(r rune) Glyph {
 	s := 0
 	e := len(font.Glyphs) - 1
 
@@ -92,7 +94,7 @@ func (font *Font) GetGlyph(r rune) Glypher {
 			XAdvance: font.Glyphs[0].Info().XAdvance,
 			XOffset:  font.Glyphs[0].Info().XOffset,
 			YOffset:  font.Glyphs[0].Info().YOffset,
-			Bitmaps:  []byte{0},
+			Bitmaps:  emptyBitmap[:],
 		}
 		return g
 	}

--- a/const2bit/const2bit.go
+++ b/const2bit/const2bit.go
@@ -65,8 +65,8 @@ func (glyph Glyph) Draw(display drivers.Displayer, x int16, y int16, c color.RGB
 }
 
 // Info returns glyph information.
-func (glyph Glyph) Info() *tinyfont.GlyphInfo {
-	return &tinyfont.GlyphInfo{
+func (glyph Glyph) Info() tinyfont.GlyphInfo {
+	return tinyfont.GlyphInfo{
 		Rune:     glyph.Rune,
 		Width:    glyph.Width,
 		Height:   glyph.Height,

--- a/display.go
+++ b/display.go
@@ -13,8 +13,8 @@ type RotatedDisplay struct {
 	Y        int16
 }
 
-func NewRotatedDisplay(display drivers.Displayer, rotation Rotation, x, y int16) *RotatedDisplay {
-	return &RotatedDisplay{
+func NewRotatedDisplay(display drivers.Displayer, rotation Rotation, x, y int16) RotatedDisplay {
+	return RotatedDisplay{
 		display:  display,
 		Rotation: rotation,
 		X:        x,
@@ -22,7 +22,7 @@ func NewRotatedDisplay(display drivers.Displayer, rotation Rotation, x, y int16)
 	}
 }
 
-func (d *RotatedDisplay) Size() (int16, int16) {
+func (d RotatedDisplay) Size() (int16, int16) {
 	x, y := d.display.Size()
 	if d.Rotation == NO_ROTATION {
 		return x, y
@@ -35,7 +35,7 @@ func (d *RotatedDisplay) Size() (int16, int16) {
 	}
 }
 
-func (d *RotatedDisplay) SetPixel(x, y int16, c color.RGBA) {
+func (d RotatedDisplay) SetPixel(x, y int16, c color.RGBA) {
 	if d.Rotation == NO_ROTATION {
 		d.display.SetPixel(d.X+x, d.Y+y, c)
 	} else if d.Rotation == ROTATION_90 {
@@ -47,6 +47,6 @@ func (d *RotatedDisplay) SetPixel(x, y int16, c color.RGBA) {
 	}
 }
 
-func (d *RotatedDisplay) Display() error {
+func (d RotatedDisplay) Display() error {
 	return d.display.Display()
 }

--- a/tinyfont.go
+++ b/tinyfont.go
@@ -65,13 +65,12 @@ func WriteLineRotated(display drivers.Displayer, font Fonter, x int16, y int16, 
 // WriteLineColors writes a string in the selected font in the buffer. Each char is in a different color
 // if not enough colors are defined, colors are cycled.
 func WriteLineColors(display drivers.Displayer, font Fonter, x int16, y int16, str string, colors []color.RGBA) {
-	WriteLineColorsRotated(display, font, x, y, str, colors, 0)
+	WriteLineColorsRotated(display, font, x, y, str, colors, NO_ROTATION)
 }
 
 // WriteLineColorsRotated writes a string in the selected font in the buffer. Each char is in a different color
 // if not enough colors are defined, colors are cycled.
 func WriteLineColorsRotated(display drivers.Displayer, font Fonter, x int16, y int16, str string, colors []color.RGBA, rotation Rotation) {
-	text := []rune(str)
 	numColors := uint16(len(colors))
 	if numColors == 0 {
 		return
@@ -80,17 +79,16 @@ func WriteLineColorsRotated(display drivers.Displayer, font Fonter, x int16, y i
 	rd := NewRotatedDisplay(display, rotation, x, y)
 
 	c := uint16(0)
-	l := len(text)
 	nx := int16(0)
 	ny := int16(0)
-	for i := 0; i < l; i++ {
-		if text[i] == LineFeed || text[i] == CarriageReturn {
+	for _, text := range str {
+		if text == LineFeed || text == CarriageReturn {
 			/* CR or LF */
 			nx = 0
 			ny += int16(font.GetYAdvance())
 			continue
 		}
-		glyph := font.GetGlyph(text[i])
+		glyph := font.GetGlyph(text)
 		glyph.Draw(rd, nx, ny, colors[c])
 		c++
 		if c >= numColors {
@@ -102,22 +100,21 @@ func WriteLineColorsRotated(display drivers.Displayer, font Fonter, x int16, y i
 
 // LineWidth returns the inner and outbox widths corresponding to font and str.
 func LineWidth(f Fonter, str string) (innerWidth uint32, outboxWidth uint32) {
-	text := []rune(str)
-	if len(text) == 0 {
+	if len(str) == 0 {
 		return
 	}
 
-	for i := range text {
-		glyph := f.GetGlyph(text[i])
+	for _, text := range str {
+		glyph := f.GetGlyph(text)
 		outboxWidth += uint32(glyph.Info().XAdvance)
 	}
 	innerWidth = outboxWidth
 	// first glyph
-	glyph := f.GetGlyph(text[0])
+	glyph := f.GetGlyph(rune(str[0]))
 	innerWidth -= uint32(glyph.Info().XOffset)
 
 	// last glyph
-	glyph = f.GetGlyph(text[len(text)-1])
+	glyph = f.GetGlyph(rune(str[len(str)-1]))
 	innerWidth += -uint32(glyph.Info().XAdvance) + uint32(glyph.Info().XOffset) + uint32(glyph.Info().Width)
 	return
 }

--- a/tinyfont.go
+++ b/tinyfont.go
@@ -30,14 +30,14 @@ type GlyphInfo struct {
 
 // Fonter is an interface that represents a set of glyphs.
 type Fonter interface {
-	GetGlyph(r rune) Glypher
+	GetGlyph(r rune) Glyph
 	GetYAdvance() uint8
 }
 
 // Glypher is glyph itself, and it knows how to draw itself.
 type Glypher interface {
 	Draw(display drivers.Displayer, x int16, y int16, color color.RGBA)
-	Info() *GlyphInfo
+	Info() GlyphInfo
 }
 
 // DrawChar sets a single rune in the buffer of the display.
@@ -123,6 +123,6 @@ func LineWidth(f Fonter, str string) (innerWidth uint32, outboxWidth uint32) {
 }
 
 // GetGlyph returns the glyph corresponding to the specified rune in the font.
-func GetGlyph(f Fonter, r rune) Glypher {
+func GetGlyph(f Fonter, r rune) Glyph {
 	return f.GetGlyph(r)
 }


### PR DESCRIPTION
This PR modifies TinyFont to avoid all heap allocations, so that it can be called safely from within interrupt handlers.

It also includes a commit to fix the `Makefile` so running `make` by itself works as expected.