### PR TITLE
Extend the CharsetRegistry to cover jisx

### DIFF
--- a/cmd/tinyfontgen/gen.go
+++ b/cmd/tinyfontgen/gen.go
@@ -96,9 +96,8 @@ func (f *fontgen) generate(w io.Writer, runes []rune, opt ...option) error {
 		}
 
 		code2rune := func(c int) (rune, error) { return rune(c), nil }
-		switch strings.ToLower(font.CharsetRegistry) {
-		case "iso08859":
-		case "jisx0208.1990":
+		charset := strings.ToLower(font.CharsetRegistry)
+		if strings.HasPrefix(charset, "jisx") {
 			code2rune = jisx0208.Rune
 		}
 

--- a/cmd/tinyfontgen/gen.go
+++ b/cmd/tinyfontgen/gen.go
@@ -97,7 +97,8 @@ func (f *fontgen) generate(w io.Writer, runes []rune, opt ...option) error {
 
 		code2rune := func(c int) (rune, error) { return rune(c), nil }
 		charset := strings.ToLower(font.CharsetRegistry)
-		if strings.HasPrefix(charset, "jisx") {
+		if charset == "jisx0201.1976" {
+		} else if strings.HasPrefix(charset, "jisx") {
 			code2rune = jisx0208.Rune
 		}
 


### PR DESCRIPTION
Add support for jisx0208.1983 and jisx0213.2000, in addition to the current support for jisx0208.1990

```
# k12-2000-1.bdf
CHARSET_REGISTRY "JISX0213.2000"
```

```
# knj10.bdf
CHARSET_REGISTRY "jisx0208.1983"
```
