### PR TITLE
Add support for gopher-badge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ fmt-check:
 
 TARGET = build/examples_epd.hex \
 		 build/examples_hub75.hex \
+		 build/examples_displays_gopher-badge.hex \
 		 build/examples_displays_pybadge.hex \
 		 build/examples_displays_pyportal.hex \
 		 build/examples_displays_wioterminal.hex \
@@ -36,6 +37,10 @@ build/examples_epd.hex:
 
 build/examples_hub75.hex:
 	$(TINYGO) build -size short -o $@ -target=pybadge ./examples/hub75
+	@$(MD5SUM) $@
+
+build/examples_displays_gopher-badge.hex:
+	$(TINYGO) build -size short -o $@ -target=gopher-badge ./examples/displays
 	@$(MD5SUM) $@
 
 build/examples_displays_pybadge.hex:

--- a/examples/initdisplay/gopher-badge.go
+++ b/examples/initdisplay/gopher-badge.go
@@ -1,0 +1,33 @@
+//go:build gopher_badge
+
+package initdisplay
+
+import (
+	"image/color"
+	"machine"
+
+	"tinygo.org/x/drivers"
+	"tinygo.org/x/drivers/st7789"
+)
+
+// InitDisplay initializes the display of each board.
+func InitDisplay() drivers.Displayer {
+	machine.SPI0.Configure(machine.SPIConfig{
+		Frequency: 8000000,
+		Mode:      0,
+	})
+
+	d := st7789.New(machine.SPI0,
+		machine.TFT_RST,       // TFT_RESET
+		machine.TFT_WRX,       // TFT_DC
+		machine.TFT_CS,        // TFT_CS
+		machine.TFT_BACKLIGHT) // TFT_LITE
+
+	d.Configure(st7789.Config{
+		Rotation: st7789.NO_ROTATION,
+		Height:   320,
+	})
+	d.FillScreen(color.RGBA{255, 255, 255, 255})
+
+	return &d
+}


### PR DESCRIPTION
I think it would be better if the gopher-badge, which is used in hack sessions and other events, could easily be used to try out examples as well.

![image](https://github.com/user-attachments/assets/15b71cba-ff04-49a5-b867-9e9cc74ad12c)
