### PR TITLE
Bugfix/multiple fonts

### DIFF
--- a/cmd/tinyfontgen-ttf/main.go
+++ b/cmd/tinyfontgen-ttf/main.go
@@ -94,9 +94,10 @@ func main() {
 
 func run(size, dpi int, fonts []string) error {
 	type xx struct {
-		Rune  rune
-		Index uint16
-		Face  font.Face
+		Rune     rune
+		Index    uint16
+		Face     font.Face
+		Filename string
 	}
 	indexes := []xx{}
 
@@ -129,6 +130,7 @@ func run(size, dpi int, fonts []string) error {
 					Rune:  r,
 					Index: uint16(idx),
 					Face:  face,
+					Filename: fontfile,
 				})
 			}
 		}
@@ -166,6 +168,7 @@ func run(size, dpi int, fonts []string) error {
 		}
 
 		font.Glyphs[i].Rune = xxx.Rune
+		font.Glyphs[i].Filename = filepath.Base(xxx.Filename)
 		font.Glyphs[i].Width = uint8(img.Bounds().Max.X - img.Bounds().Min.X)
 		font.Glyphs[i].Height = uint8(img.Bounds().Max.Y - img.Bounds().Min.Y)
 		font.Glyphs[i].XAdvance = uint8(adv.Ceil())
@@ -207,6 +210,7 @@ type Glyph struct {
 	XOffset  int8
 	YOffset  int8
 	Bitmaps  []byte
+	Filename string
 }
 
 // Font is a struct that implements Fonter interface.
@@ -246,7 +250,7 @@ func (f Font) SaveTo(w io.Writer) {
 		fmt.Fprintf(w, `	"\x%02X\x%02X\x%02X" + `, byte(x.Rune>>16), byte(x.Rune>>8), byte(x.Rune))
 		fmt.Fprintf(w, `"\x%02X\x%02X\x%02X" + `, byte(offset>>16), byte(offset>>8), byte(offset))
 		if x.Rune > 0 {
-			fmt.Fprintf(w, `// %c`, x.Rune)
+			fmt.Fprintf(w, `// %c %s`, x.Rune, x.Filename)
 		} else {
 			fmt.Fprintf(w, `//`)
 		}

--- a/cmd/tinyfontgen-ttf/main.go
+++ b/cmd/tinyfontgen-ttf/main.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"golang.org/x/image/font"
@@ -100,8 +101,7 @@ func run(size, dpi int, fonts []string) error {
 		Filename string
 	}
 	indexes := []xx{}
-	seen := map[rune]string{} 
-
+	seen := map[rune]string{}
 
 	for _, fontfile := range fonts {
 		bb, err := ioutil.ReadFile(fontfile)
@@ -130,8 +130,8 @@ func run(size, dpi int, fonts []string) error {
 			if idx != 0 && (*all || runesMap[r]) {
 				if first, ok := seen[r]; ok {
 					fmt.Fprintf(os.Stderr,
-					"warning: rune U+%04X (%c) already registered from %s, skipping from %s\n",
-					r, r, filepath.Base(first), filepath.Base(fontfile))
+						"warning: rune U+%04X (%c) already registered from %s, skipping from %s\n",
+						r, r, filepath.Base(first), filepath.Base(fontfile))
 					continue
 				}
 				seen[r] = fontfile
@@ -144,7 +144,9 @@ func run(size, dpi int, fonts []string) error {
 			}
 		}
 	}
-
+	sort.Slice(indexes, func(i, j int) bool {
+		return indexes[i].Rune < indexes[j].Rune
+	})
 	fontBuffer := [256]uint8{}
 	font := Font{
 		Glyphs: make([]Glyph, len(indexes)),

--- a/cmd/tinyfontgen-ttf/main.go
+++ b/cmd/tinyfontgen-ttf/main.go
@@ -100,6 +100,8 @@ func run(size, dpi int, fonts []string) error {
 		Filename string
 	}
 	indexes := []xx{}
+	seen := map[rune]string{} 
+
 
 	for _, fontfile := range fonts {
 		bb, err := ioutil.ReadFile(fontfile)
@@ -126,10 +128,17 @@ func run(size, dpi int, fonts []string) error {
 				return err
 			}
 			if idx != 0 && (*all || runesMap[r]) {
+				if first, ok := seen[r]; ok {
+					fmt.Fprintf(os.Stderr,
+					"warning: rune U+%04X (%c) already registered from %s, skipping from %s\n",
+					r, r, filepath.Base(first), filepath.Base(fontfile))
+					continue
+				}
+				seen[r] = fontfile
 				indexes = append(indexes, xx{
-					Rune:  r,
-					Index: uint16(idx),
-					Face:  face,
+					Rune:     r,
+					Index:    uint16(idx),
+					Face:     face,
 					Filename: fontfile,
 				})
 			}


### PR DESCRIPTION
### Assumptions
The output is now sorted by rune and ensures uniqueness.  
This matches the assumptions made by const2bit.GetGlyph,
which relies on binary search and does not support duplicate runes.

### Summary
This PR fixes the unstable font generation when using multiple font files.

- Added a duplicate glyph check:
  - The first font that provides the glyph will be used.
  - Subsequent duplicates are skipped with a warning to stderr.
- Sorted glyphs by rune codepoint to make the output deterministic.
- Added font file information in comments of the generated code:
  - Helps debugging when multiple fonts are used.
  - Clarifies font origin for license management.

### Why
Previously, glyphs could be duplicated or appear in non-deterministic order,
which caused incorrect behavior.  

For example, **NotoSansJP-Regular.ttf** and **NotoSansKR-Regular.ttf** are CJK fonts
that embed very large character sets. Each font includes not only Japanese or
Korean characters but also full sets of Latin, Greek, Cyrillic, and other
Euro-zone glyphs. As a result, there is a huge overlap (e.g. punctuation,
Latin letters).  

When these fonts are combined, many runes appear multiple times and the generated
order becomes non-deterministic. This PR resolves these issues by enforcing
uniqueness and sorting.
