### PR TITLE
fix: GetGlyph falls back to index 0 when rune is not found

### DIFF
--- a/const1bit/const1bit.go
+++ b/const1bit/const1bit.go
@@ -77,28 +77,34 @@ func (f *Font) GetYAdvance() uint8 {
 }
 
 // GetGlyph returns the glyph corresponding to the specified rune in the font.
+// If the rune does not exist in the font, the glyph at index 0 will be returned as a fallback.
 // Since there is only one glyph used for the return value in this package,
 // concurrent access is not allowed. Normally, there is no issue when using it from tinyfont.
 func (font *Font) GetGlyph(r rune) tinyfont.Glypher {
 	s := 0
 	e := len(font.OffsetMap)/6 - 1
+	found := false
 
 	for s <= e {
 		m := (s + e) / 2
-
 		r2 := rune(font.OffsetMap[m*6])<<16 + rune(font.OffsetMap[m*6+1])<<8 + rune(font.OffsetMap[m*6+2])
-		if r2 < r {
+		if r2 == r {
+			s = m
+			found = true
+			break
+		} else if r2 < r {
 			s = m + 1
 		} else {
 			e = m - 1
 		}
 	}
 
-	if s > len(font.OffsetMap)/6-1 {
+	if !found {
 		s = 0
 	}
 
 	offset := uint32(font.OffsetMap[s*6+3])<<16 + uint32(font.OffsetMap[s*6+4])<<8 + uint32(font.OffsetMap[s*6+5])
+
 	sz := uint32(len(font.Data[offset+5:]))
 	if s*6+6 < len(font.OffsetMap) {
 		sz = uint32(font.OffsetMap[s*6+9])<<16 + uint32(font.OffsetMap[s*6+10])<<8 + uint32(font.OffsetMap[s*6+11]) - offset
@@ -111,5 +117,5 @@ func (font *Font) GetGlyph(r rune) tinyfont.Glypher {
 	font.glyph.XOffset = int8(font.Data[offset+3])
 	font.glyph.YOffset = int8(font.Data[offset+4])
 	font.glyph.Bitmaps = []byte(font.Data[offset+5 : offset+5+sz])
-	return &(font.glyph)
+	return &font.glyph
 }

--- a/const1bit/const1bit.go
+++ b/const1bit/const1bit.go
@@ -104,7 +104,6 @@ func (font *Font) GetGlyph(r rune) tinyfont.Glypher {
 	}
 
 	offset := uint32(font.OffsetMap[s*6+3])<<16 + uint32(font.OffsetMap[s*6+4])<<8 + uint32(font.OffsetMap[s*6+5])
-
 	sz := uint32(len(font.Data[offset+5:]))
 	if s*6+6 < len(font.OffsetMap) {
 		sz = uint32(font.OffsetMap[s*6+9])<<16 + uint32(font.OffsetMap[s*6+10])<<8 + uint32(font.OffsetMap[s*6+11]) - offset
@@ -117,5 +116,5 @@ func (font *Font) GetGlyph(r rune) tinyfont.Glypher {
 	font.glyph.XOffset = int8(font.Data[offset+3])
 	font.glyph.YOffset = int8(font.Data[offset+4])
 	font.glyph.Bitmaps = []byte(font.Data[offset+5 : offset+5+sz])
-	return &font.glyph
+	return &(font.glyph)
 }

--- a/const2bit/const2bit.go
+++ b/const2bit/const2bit.go
@@ -110,7 +110,6 @@ func (font *Font) GetGlyph(r rune) tinyfont.Glypher {
 	}
 
 	offset := uint32(font.OffsetMap[s*6+3])<<16 + uint32(font.OffsetMap[s*6+4])<<8 + uint32(font.OffsetMap[s*6+5])
-
 	sz := uint32(len(font.Data[offset+5:]))
 	if s*6+6 < len(font.OffsetMap) {
 		sz = uint32(font.OffsetMap[s*6+9])<<16 + uint32(font.OffsetMap[s*6+10])<<8 + uint32(font.OffsetMap[s*6+11]) - offset
@@ -123,5 +122,5 @@ func (font *Font) GetGlyph(r rune) tinyfont.Glypher {
 	font.glyph.XOffset = int8(font.Data[offset+3])
 	font.glyph.YOffset = int8(font.Data[offset+4])
 	font.glyph.Bitmaps = []byte(font.Data[offset+5 : offset+5+sz])
-	return &font.glyph
+	return &(font.glyph)
 }

--- a/const2bit/const2bit.go
+++ b/const2bit/const2bit.go
@@ -83,28 +83,34 @@ func (f *Font) GetYAdvance() uint8 {
 }
 
 // GetGlyph returns the glyph corresponding to the specified rune in the font.
+// If the rune does not exist in the font, the glyph at index 0 will be returned as a fallback.
 // Since there is only one glyph used for the return value in this package,
 // concurrent access is not allowed. Normally, there is no issue when using it from tinyfont.
 func (font *Font) GetGlyph(r rune) tinyfont.Glypher {
 	s := 0
 	e := len(font.OffsetMap)/6 - 1
+	found := false
 
 	for s <= e {
 		m := (s + e) / 2
-
 		r2 := rune(font.OffsetMap[m*6])<<16 + rune(font.OffsetMap[m*6+1])<<8 + rune(font.OffsetMap[m*6+2])
-		if r2 < r {
+		if r2 == r {
+			s = m
+			found = true
+			break
+		} else if r2 < r {
 			s = m + 1
 		} else {
 			e = m - 1
 		}
 	}
 
-	if s > len(font.OffsetMap)/6-1 {
+	if !found {
 		s = 0
 	}
 
 	offset := uint32(font.OffsetMap[s*6+3])<<16 + uint32(font.OffsetMap[s*6+4])<<8 + uint32(font.OffsetMap[s*6+5])
+
 	sz := uint32(len(font.Data[offset+5:]))
 	if s*6+6 < len(font.OffsetMap) {
 		sz = uint32(font.OffsetMap[s*6+9])<<16 + uint32(font.OffsetMap[s*6+10])<<8 + uint32(font.OffsetMap[s*6+11]) - offset
@@ -117,5 +123,5 @@ func (font *Font) GetGlyph(r rune) tinyfont.Glypher {
 	font.glyph.XOffset = int8(font.Data[offset+3])
 	font.glyph.YOffset = int8(font.Data[offset+4])
 	font.glyph.Bitmaps = []byte(font.Data[offset+5 : offset+5+sz])
-	return &(font.glyph)
+	return &font.glyph
 }


### PR DESCRIPTION
This pull request fixes an issue where `GetGlyph` could return the glyph of the next larger rune if the requested rune was not found in the font.  
As a result, undefined characters could be rendered as completely unrelated glyphs (see #58).

### Changes
- Updated `GetGlyph` in both `const1bit` and `const2bit` packages:
  - Added an equality check (`==`) during the binary search.
  - Introduced a `found` flag to ensure that if no match is found, the function always falls back to index 0.
- Updated function comments to explicitly state that undefined runes return the glyph at index 0.

### Verification
- Verified with `const2bit` fonts (WebAssembly rendering).  
- Could not test with `const1bit` fonts locally, but the implementation is identical.

```
tinyfont.WriteLine(target, &testfont, 10, 50, "①②③④⑤", color.RGBA{0, 0, 0, 255})
```

<img width="1056" height="619" alt="image" src="https://github.com/user-attachments/assets/26f75cad-00ec-4b68-946a-1022510f7ae6" />

### Impact
- Undefined runes will no longer render as unrelated valid glyphs.  
- Instead, they consistently fall back to glyph 0 (commonly a space or placeholder).




Fixes #58