### PR TITLE
build: use TinyGo latest release for CI builds.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,16 +11,17 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ghcr.io/tinygo-org/tinygo-dev
+    container:
+      image: ghcr.io/tinygo-org/tinygo:latest
+      options: --user root
     steps:
-      - name: Work around CVE-2022-24765
-        # We're not on a multi-user machine, so this is safe.
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: TinyGo version check
         run: tinygo version
       - name: Enforce Go Formatted Code
         run: make fmt-check
       - name: Run build and smoke tests
-        run: make smoke-test
+        run: |
+          go env -w GOFLAGS=-buildvcs=false
+          make smoke-test


### PR DESCRIPTION
This PR switches to use the TinyGo latest release for CI builds.